### PR TITLE
Make compatible with latest version of stackage (7.2)

### DIFF
--- a/discogs-haskell.cabal
+++ b/discogs-haskell.cabal
@@ -46,20 +46,20 @@ library
   default-language: Haskell2010
   hs-source-dirs: src/
   build-depends:
-    base >= 4.6 && < 4.9,
-    aeson >= 0.9 && < 0.10,
+    base >= 4.6 && < 4.10,
+    aeson >= 0.9 && < 1.1,
     bytestring == 0.10.*,
-    data-default-class == 0.0.1,
+    data-default-class >= 0.0.1 && < 0.2,
     free >= 4 && < 5,
-    http-client == 0.4.20,
-    http-client-tls >= 0.2 && < 0.2.3,
-    http-types == 0.8.6,
+    http-client >= 0.4.20 && < 0.6,
+    http-client-tls >= 0.2 && < 0.4,
+    http-types >= 0.8.6 && < 0.10,
     network == 2.6.*,
-    api-builder == 0.11.0.0,
+    api-builder >= 0.11 && < 0.13,
     text == 1.*,
-    time == 1.5.*,
-    transformers == 0.4.*,
-    unordered-containers == 0.2.5.*,
+    time >= 1.5 && < 1.7,
+    transformers >=  0.4 && < 0.6,
+    unordered-containers >= 0.2.5 && < 0.3,
     vector >= 0.10 && < 0.12
   ghc-options: -Wall
 
@@ -93,4 +93,3 @@ source-repository this
   type:     git
   location: http://github.com/accraze/discogs-haskell
   tag:      0.0.5.0
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,18 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.1
+resolver: lts-7.2
 
 # Local packages, usually specified by relative directory name
 packages:
-- '.'
+- location: .
+- location:
+    git: git@github.com:WillSewell/api-builder.git
+    commit: 39a0f96703dcf707ca0364a0580e33f9efd12631
+  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: 
-- 'api-builder-0.11.0.0'
-- 'http-types-0.8.6'
-- 'http-client-0.4.20'
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
@accraze this should do the job. The problem is that because of https://github.com/accraze/discogs-haskell/issues/1#issuecomment-251894223 I had to for the library and bump the deps. We could either wait for this to be merged, or just stick with my fork.
